### PR TITLE
Update README.md with token list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Mantle token list is used as the source of truth for the [Mantle Bridge](https://bridge.testnet.mantle.xyz/deposit) which is the main portal for moving assets between Layer 1 and Layer 2.
 
+## Fetching Token list
+
+Once a change get merged it will automatically be added to the list and can be fetched from the [token list](/mantle.tokenlist.json) as json.
+
 ## Review process and merge criteria
 
 ### Process overview


### PR DESCRIPTION
Add link to the generated json format to people understand where they can fetch the list from, if they are seeing the readme the link will point to the file, on https://token-list.mantle.xyz the link should point to https://token-list.mantle.xyz/mantle.tokenlist.json