### PR TITLE
Update data.json files for including LINK and UNI in the token list for Mantle Mainnet

### DIFF
--- a/data/LINK/data.json
+++ b/data/LINK/data.json
@@ -3,6 +3,12 @@
   "symbol": "LINK",
   "decimals": 18,
   "tokens": {
+     "ethereum": {
+      "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+    },
+    "mantle": {
+      "address": "0x3B9d0D149070b952199943838a2c853dE0DAC776"
+    },   
     "goerli": {
       "address": "0x326C977E6efc84E512bB9C30f76E30c160eD06FB"
     },

--- a/data/UNI/data.json
+++ b/data/UNI/data.json
@@ -3,6 +3,12 @@
   "symbol": "UNI",
   "decimals": 18,
   "tokens": {
+    "ethereum": {
+      "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+    },
+    "mantle": {
+      "address": "0x9C1012C978352d8BaFd584377871046F1e3B1344"
+    },    
     "goerli": {
       "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
     },


### PR DESCRIPTION
These tokens are in the token list for testnet, but not for the mainnet. 