### PR TITLE
feat: replace goerli testnet with hoodi network

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ Add a file to your folder called `data.json` with the following format:
     "mantle": {
       "address": "0x2345234523452345234523452345234523452345"
     },
-    "goerli": {
+    "sepolia": {
       "address": "0x5678567856785678567856785678567856785678"
     },
-    "mantle-goerli": {
+    "mantle-sepolia": {
       "address": "0x6789678967896789678967896789678967896789"
+    },
+    "hoodi": {
+      "address": "0x7890789078907890789078907890789078907890"
+    },
+    "mantle-hoodi": {
+      "address": "0x8901890189018901890189018901890189018901"
     }
   }
 }
@@ -83,8 +89,10 @@ We currently accept tokens on the following chains:
 
 - `ethereum`
 - `mantle`
-- `goerli`
-- `mantle-goerli`
+- `sepolia`
+- `mantle-sepolia`
+- `hoodi`
+- `mantle-hoodi`
 
 #### Non-bridgable tokens
 

--- a/data/APEX/data.json
+++ b/data/APEX/data.json
@@ -6,12 +6,6 @@
   "website": "https://pro.apex.exchange",
   "twitter": "@OfficialApeXdex",
   "tokens": {
-    "goerli": {
-      "address": "0x6fDd9fa8237883de7c2ebC6908Ab9e243600567E"
-    },
-    "mantle-goerli": {
-      "address": "0x0D957d9664113ec8F727763B54a209FA2D112224"
-    },
     "ethereum": {
       "address": "0x52A8845DF664D76C69d2EEa607CD793565aF42B8"
     },

--- a/data/Babydoge/data.json
+++ b/data/Babydoge/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x3e65Ac1DD4938e02301c4869d3043903F5dEB474"
-    },
-    "goerli": {
-      "address": "0xdaEa7414F54929d637F601Eb0B545BfE5384e1F4"
-    },
-    "mantle-goerli": {
-      "address": "0x20cc47b797e50f2b9ecaC0A6445D8a9E149856c1"
     }
   },
   "tickers": {

--- a/data/ETH/data.json
+++ b/data/ETH/data.json
@@ -9,16 +9,16 @@
     "mantle": {
       "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
     },
-    "goerli": {
-      "address": "0x0000000000000000000000000000000000000000"
-    },
-    "mantle-goerli": {
-      "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
-    },
     "sepolia": {
       "address": "0x0000000000000000000000000000000000000000"
     },
     "mantle-sepolia": {
+      "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
+    },
+    "hoodi": {
+      "address": "0x0000000000000000000000000000000000000000"
+    },
+    "mantle-hoodi": {
       "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
     }
   },

--- a/data/Floki/data.json
+++ b/data/Floki/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x6eFFF76AcF1698a6a215eCa7D632991678Ec673b"
-    },
-    "goerli": {
-      "address": "0xa1f61F5600EBeC912EAb557e0159e22Cdd252d53"
-    },
-    "mantle-goerli": {
-      "address": "0x491FD73b7144371c04154A2a39FE5270C2E6A96A"
     }
   },
   "tickers": {

--- a/data/IONX/data.json
+++ b/data/IONX/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x6968f3F16C3e64003F02E121cf0D5CCBf5625a42"
-    },
-    "goerli": {
-      "address": "0x0d2b6c830c4565A556bFf5417ee46A3D798a61f7"
-    },
-    "mantle-goerli": {
-      "address": "0x538EC12E9b801268913b33ea66B913691eFb310e"
     }
   },
   "tickers": {

--- a/data/LINK/data.json
+++ b/data/LINK/data.json
@@ -2,14 +2,7 @@
   "name": "Chainlink",
   "symbol": "LINK",
   "decimals": 18,
-  "tokens": {
-    "goerli": {
-      "address": "0x326C977E6efc84E512bB9C30f76E30c160eD06FB"
-    },
-    "mantle-goerli": {
-      "address": "0xA440ca6123C6d472F85c1f3930395664BCcd3d01"
-    }
-  },
+  "tokens": {},
   "tickers": {
     "coingecko": "chainlink"
   }

--- a/data/LUSD/data.json
+++ b/data/LUSD/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0xf93a85d53e4aF0D62bdf3A83CCFc1EcF3EAf9F32"
-    },
-    "goerli": {
-      "address": "0xDDb48DFDC7d6719008C39980fBF88008AA7D8306"
-    },
-    "mantle-goerli": {
-      "address": "0x06182Fa2330Ad3Bbc1fAaf69Ff188b2D349283f2"
     }
   },
   "tickers": {

--- a/data/Mantle/data.json
+++ b/data/Mantle/data.json
@@ -9,12 +9,6 @@
     "mantle": {
       "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"
     },
-    "goerli": {
-      "address": "0xc1dC2d65A2243c22344E725677A3E3BEBD26E604"
-    },
-    "mantle-goerli": {
-      "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"
-    },
     "sepolia": {
       "address": "0x65e37B558F64E2Be5768DB46DF22F93d85741A9E"
     },
@@ -28,6 +22,12 @@
       "address": "0x9c38b8ba2fdbf2f2414df70ed62d93ca492158e6"
     },
     "mantle-sepolia": {
+      "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"
+    },
+    "hoodi": {
+      "address": "0xb57837B4D0d372bF49E69Bc36c36d9Cc9488bf18"
+    },
+    "mantle-hoodi": {
       "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000"
     }
   },

--- a/data/PENDLE/data.json
+++ b/data/PENDLE/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0xd27B18915e7acc8FD6Ac75DB6766a80f8D2f5729"
-    },
-    "goerli": {
-      "address": "0xe20C2CF90f1e4AA8ABE20a6562C16B3601ad29BF"
-    },
-    "mantle-goerli": {
-      "address": "0x9F2259D6A9E016b051A9058Da05cFEedc0AB629E"
     }
   },
   "tickers": {

--- a/data/PEPE/data.json
+++ b/data/PEPE/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x8baf44B350eF672232A6673E1e128C7875640477"
-    },
-    "goerli": {
-      "address": "0xE0264C0EE9D946C593732783314C10763dEC0fEf"
-    },
-    "mantle-goerli": {
-      "address": "0xe24C3B02730C2678d1018EE6bDfAaE1Bd7480161"
     }
   },
   "tickers": {

--- a/data/RPK/data.json
+++ b/data/RPK/data.json
@@ -5,14 +5,7 @@
   "description": "RPK is utility token for Republik platform.",
   "website": "https://republik.gg",
   "twitter": "@RepubliK_GG",
-  "tokens": {
-    "goerli": {
-      "address": "0x342CD7D8CcAFa436F889F11902A58132Dc4f4B3F"
-    },
-    "mantle-goerli": {
-      "address": "0x1F233585349B065924F14600FBDC4df33aD524F8"
-    }
-  },
+  "tokens": {},
   "tickers": {
     "coingecko": "republik"
   }

--- a/data/SHIBA/data.json
+++ b/data/SHIBA/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x49397aC9CB061152B770B1D274a5682155F20099"
-    },
-    "goerli": {
-      "address": "0xE3D47d4B5EcA617f03D22B5A2B9c17aF65bBfE73"
-    },
-    "mantle-goerli": {
-      "address": "0x1Bf3876Dbe1db0Dd27D0b1cB61DEf968502f36d3"
     }
   },
   "tickers": {

--- a/data/UNI/data.json
+++ b/data/UNI/data.json
@@ -7,12 +7,6 @@
     "ethereum": {
       "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
     },
-    "goerli": {
-      "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
-    },
-    "mantle-goerli": {
-      "address": "0x7AD75528ad538B8E28b624033DD3C10F2Ad96a37"
-    },
     "mantle": {
       "address": "0x2dB08783F13c4225A1963b2437f0D459a5BCB4D8"
     }

--- a/data/USDC/data.json
+++ b/data/USDC/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9"
-    },
-    "goerli": {
-      "address": "0x07865c6E87B9F70255377e024ace6630C1Eaa37F"
-    },
-    "mantle-goerli": {
-      "address": "0x2ED3c15eC59CE827c4aBBabfF76d37562558437D"
     }
   },
   "tickers": {

--- a/data/USDLR/data.json
+++ b/data/USDLR/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x8FE7176F0BF63358ad9490fd24Ac0bdB4Dac33a8"
-    },
-    "goerli": {
-      "address": "0x335ebba91118eb2c3d1ca23f124c4b9901e3323d"
-    },
-    "mantle-goerli": {
-      "address": "0xcA6BaE3b11d07fa4583fA2fc4c8B0EE546DeCa9E"
     }
   },
   "tickers": {

--- a/data/USDT/data.json
+++ b/data/USDT/data.json
@@ -11,12 +11,6 @@
     },
     "mantle": {
       "address": "0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE"
-    },
-    "goerli": {
-      "address": "0xC2C527C0CACF457746Bd31B2a698Fe89de2b6d49"
-    },
-    "mantle-goerli": {
-      "address": "0x27ee0eB6EbbcbCd4706C3291604AdC2F4384d09F"
     }
   },
   "tickers": {

--- a/data/WBTC/data.json
+++ b/data/WBTC/data.json
@@ -11,13 +11,6 @@
     },
     "mantle": {
       "address": "0xCAbAE6f6Ea1ecaB08Ad02fE02ce9A44F09aebfA2"
-    },
-    "goerli": {
-      "address": "0xC04B0d3107736C32e19F1c62b2aF67BE61d63a05"
-    },
-    "mantle-goerli": {
-      "address": "0x9155d6bFD923398D77292a2781D3E4acfD3cFFd6",
-      "overrides": { "name": "Wrapped BTC L2" }
     }
   },
   "tickers": {

--- a/data/mETH/data.json
+++ b/data/mETH/data.json
@@ -14,12 +14,6 @@
     },
     "mantle-sepolia": {
       "address": "0x9EF6f9160Ba00B6621e5CB3217BB8b54a92B2828"
-    },
-    "goerli": {
-      "address": "0x20d7E093B3fa5eBfA7a0fa414FaD547743a2400F"
-    },
-    "mantle-goerli": {
-      "address": "0x5fc6fe32871642Ea04E0651F54BE80546cF2173b"
     }
   },
   "tickers": {

--- a/data/wstETH/data.json
+++ b/data/wstETH/data.json
@@ -15,18 +15,6 @@
         "bridge": "0x9c46560D6209743968cC24150893631A39AfDe4d"
       }
     },
-    "goerli": {
-      "address": "0x6320cD32aA674d2898A68ec82e869385Fc5f7E2f",
-      "overrides": {
-        "bridge": "0x2fD573Ace456904709444d04AdCa189fB19e725a"
-      }
-    },
-    "mantle-goerli": {
-      "address": "0x4CAD3137E9e6994A6E9442e723B7EEF04335C944",
-      "overrides": {
-        "bridge": "0x08C2EE913D3cb544D182bCC7632cB0B382A2933e"
-      }
-    },
     "sepolia": {
       "address": "0xB82381A3fBD3FaFA77B3a7bE693342618240067b",
       "overrides": {

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -9,19 +9,21 @@ export const NETWORK_DATA = {
     pair: 'optimism',
     bridge: '0x95fC37A27a2f68e3A647CDc081F0A89bb47c3012',
   },
-  goerli: {
-    id: 5,
-    name: 'Goerli',
-    provider: new ethers.providers.InfuraProvider('goerli'),
+  hoodi: {
+    id: 560048,
+    name: 'Hoodi',
+    provider: new ethers.providers.StaticJsonRpcProvider(
+      'https://0xrpc.io/hoodi'
+    ),
     layer: 1,
-    pair: 'mantle-goerli',
-    bridge: '0xc92470D7Ffa21473611ab6c6e2FcFB8637c8f330',
+    pair: 'mantle-hoodi',
+    bridge: '0x9A28426964b13791f07e9C19afe797b0c69a004c',
   },
-  'mantle-goerli': {
+  'mantle-hoodi': {
     id: 5001,
     name: 'mantle',
     provider: new ethers.providers.StaticJsonRpcProvider(
-      'https://rpc.testnet.mantle.xyz'
+      'https://rpc.hoodi.mantle.xyz'
     ),
     layer: 2,
     pair: 'mantle',
@@ -69,7 +71,7 @@ export const NETWORK_DATA = {
     id: 11155111,
     name: 'sepolia',
     provider: new ethers.providers.StaticJsonRpcProvider(
-      'https://rpc.ankr.com/eth_sepolia'
+      'https://11155111.rpc.thirdweb.com'
     ),
     layer: 1,
     pair: 'mantle-sepolia',
@@ -79,7 +81,7 @@ export const NETWORK_DATA = {
     id: 5003,
     name: 'mantle',
     provider: new ethers.providers.StaticJsonRpcProvider(
-      'https://rpc-internal.sepolia.mantle.xyz'
+      'https://rpc.sepolia.mantle.xyz'
     ),
     layer: 2,
     pair: 'mantle',

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,6 +8,7 @@ export const TOKEN_SCHEMA = {
   type: 'object',
   properties: {
     address: ADDRESS_TYPE,
+    adapter: ADDRESS_TYPE,
     overrides: {
       bridge: ADDRESS_TYPE,
       name: {
@@ -56,92 +57,48 @@ export const TOKEN_DATA_SCHEMA = {
       type: 'string',
     },
     tokens: {
-      oneOf: [
-        {
+      type: 'object',
+      properties: {
+        ethereum: TOKEN_SCHEMA,
+        mantle: TOKEN_SCHEMA,
+        hoodi: TOKEN_SCHEMA,
+        'mantle-hoodi': TOKEN_SCHEMA,
+        sepolia: TOKEN_SCHEMA,
+        'mantle-sepolia': TOKEN_SCHEMA,
+        bsc: TOKEN_SCHEMA,
+        'bsc-testnet': TOKEN_SCHEMA,
+        hyperliquid: TOKEN_SCHEMA,
+        'hyperliquid-testnet': TOKEN_SCHEMA,
+      },
+      additionalProperties: false,
+    },
+    tickers: {
+      type: 'object',
+      properties: {
+        coingecko: { type: 'string' },
+      },
+      additionalProperties: false,
+    },
+    extensions: {
+      type: 'object',
+      properties: {
+        thirdparty: {
           type: 'object',
           properties: {
-            ethereum: TOKEN_SCHEMA,
-            optimism: TOKEN_SCHEMA,
-            kovan: TOKEN_SCHEMA,
-            'optimism-kovan': TOKEN_SCHEMA,
+            name: { type: 'string' },
+            url: { type: 'string' },
           },
-          additionalProperties: false,
-          required: ['ethereum', 'optimism', 'kovan', 'optimism-kovan'],
         },
-        {
+        external: {
           type: 'object',
           properties: {
-            ethereum: TOKEN_SCHEMA,
-            optimism: TOKEN_SCHEMA,
-            goerli: TOKEN_SCHEMA,
-            'optimism-goerli': TOKEN_SCHEMA,
+            name: { type: 'string' },
+            url: { type: 'string' },
           },
-          additionalProperties: false,
-          required: ['ethereum', 'optimism', 'goerli', 'optimism-goerli'],
         },
-        {
-          type: 'object',
-          properties: {
-            ethereum: TOKEN_SCHEMA,
-            optimism: TOKEN_SCHEMA,
-            kovan: TOKEN_SCHEMA,
-            'optimism-kovan': TOKEN_SCHEMA,
-            goerli: TOKEN_SCHEMA,
-            'optimism-goerli': TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: [
-            'ethereum',
-            'optimism',
-            'kovan',
-            'optimism-kovan',
-            'goerli',
-            'optimism-goerli',
-          ],
-        },
-        {
-          type: 'object',
-          properties: {
-            optimism: TOKEN_SCHEMA,
-            'optimism-kovan': TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: ['optimism', 'optimism-kovan'],
-        },
-        {
-          type: 'object',
-          properties: {
-            'mantle-goerli': TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: ['mantle-goerli'],
-        },
-        {
-          type: 'object',
-          properties: {
-            'mantle-goerli': TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: ['mantle-goerli'],
-        },
-        {
-          type: 'object',
-          properties: {
-            goerli: TOKEN_SCHEMA,
-            'optimism-goerli': TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: ['goerli', 'mantle-goerli'],
-        },
-        {
-          type: 'object',
-          properties: {
-            optimism: TOKEN_SCHEMA,
-          },
-          additionalProperties: false,
-          required: ['Mantle'],
-        },
-      ],
+        oft: { type: 'boolean' },
+      },
+      additionalProperties: false,
     },
   },
   additionalProperties: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,8 @@ export interface TokenData {
   website: string
   tokens: {
     ethereum?: Token
-    'mantle-goerli'?: Token
-    goerli?: Token
+    hoodi?: Token
+    'mantle-hoodi'?: Token
     sepolia?: Token
     'mantle-sepolia'?: Token
   }

--- a/tests/__snapshots__/generate.test.ts.snap
+++ b/tests/__snapshots__/generate.test.ts.snap
@@ -13,14 +13,15 @@ Object {
   "tokens": Array [
     Object {
       "address": "0x0000000000000000000000000000000000000000",
-      "chainId": 5,
+      "chainId": 560048,
       "decimals": 18,
       "extensions": Object {
-        "optimismBridgeAddress": "0x1050ec8fC7eB534c5Be07F4a0FF8641D821eE821",
+        "optimismBridgeAddress": "0x9A28426964b13791f07e9C19afe797b0c69a004c",
       },
       "logoURI": "https://token-list.mantle.xyz/data/ETH/logo.svg",
       "name": "Ether",
       "symbol": "ETH",
+      "tickers": undefined,
     },
     Object {
       "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
@@ -32,33 +33,12 @@ Object {
       "logoURI": "https://token-list.mantle.xyz/data/ETH/logo.svg",
       "name": "Ether",
       "symbol": "ETH",
-    },
-    Object {
-      "address": "0x5a94Dc6cc85fdA49d8E9A8b85DDE8629025C42be",
-      "chainId": 5,
-      "decimals": 18,
-      "extensions": Object {
-        "optimismBridgeAddress": "0x1050ec8fC7eB534c5Be07F4a0FF8641D821eE821",
-      },
-      "logoURI": "https://token-list.mantle.xyz/data/BitDAO/logo.png",
-      "name": "Mantle",
-      "symbol": "BIT",
-    },
-    Object {
-      "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
-      "chainId": 5001,
-      "decimals": 18,
-      "extensions": Object {
-        "optimismBridgeAddress": "0x4200000000000000000000000000000000000010",
-      },
-      "logoURI": "https://token-list.mantle.xyz/data/BitDAO/logo.png",
-      "name": "Mantle",
-      "symbol": "BIT",
+      "tickers": undefined,
     },
   ],
   "version": Object {
-    "major": 4,
-    "minor": 3,
+    "major": 1,
+    "minor": 0,
     "patch": 0,
   },
 }

--- a/tests/data/ETH/data.json
+++ b/tests/data/ETH/data.json
@@ -5,13 +5,10 @@
   "description": "Ethereum",
   "website": "https://ethereum.org",
   "tokens": {
-    "ethereum": {
+    "hoodi": {
       "address": "0x0000000000000000000000000000000000000000"
     },
-    "goerli": {
-      "address": "0x0000000000000000000000000000000000000000"
-    },
-    "goerli-testnet": {
+    "mantle-hoodi": {
       "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
     }
   }


### PR DESCRIPTION
- Add hoodi (chainId 560048) and mantle-hoodi (chainId 5001) network pair
- Remove deprecated goerli and mantle-goerli; mantle-hoodi inherits chainId 5001
- Add ETH and MNT token entries on hoodi / mantle-hoodi
- Strip goerli/mantle-goerli entries from all token data files
- Update chains, types, schema, README and test snapshot accordingly